### PR TITLE
fix: correct mislabeled signing party during wallet and server token

### DIFF
--- a/docs/concepts/token.md
+++ b/docs/concepts/token.md
@@ -81,9 +81,9 @@ def object WalletTokenData: "wallet token data"
 {
     + WalletTokenSeed "seed"      : "wallet token seed"
     + multibase       "sha256_pii": "multibase(sha256(personId)) - hashed PII"
-    + Provider        "provider"  : "wallet provider information"
+    + Provider        "provider"  : "CApp provider information"
     + multibase       "nonce"     : "provider nonce", byte_length(16)
-    + AssertProof     "proof"     : "provider proof - wallet provider signature"
+    + AssertProof     "proof"     : "provider proof - CApp provider signature"
 }
 ```
 
@@ -173,8 +173,8 @@ def object ServerTokenData: "server token data"
     + walletId             "walletId"  : "wallet id"
     + appId                "caAppId"   : "CApp id"
     + utcDatetime          "validUntil": "token expiration date and time"
-    + Provider             "provider"  : "provider information"
+    + Provider             "provider"  : "CApp provider information"
     + multibase            "nonce"     : "provider nonce", byte_length(16)
-    + AssertProof          "proof"     : "provider proof - provider signature"
+    + AssertProof          "proof"     : "provider proof - CApp provider signature"
 }
 ```

--- a/docs/concepts/token_ko.md
+++ b/docs/concepts/token_ko.md
@@ -81,9 +81,9 @@ def object WalletTokenData: "wallet token data"
 {
     + WalletTokenSeed "seed"      : "wallet token seed"
     + multibase       "sha256_pii": "multibase(sha256(personId)) - hashed PII"
-    + Provider        "provider"  : "월렛 사업자 정보"
+    + Provider        "provider"  : "인가앱 사업자 정보"
     + multibase       "nonce"     : "provider nonce", byte_length(16)
-    + AssertProof     "proof"     : "provider proof - 월렛 사업자 서명"
+    + AssertProof     "proof"     : "provider proof - 인가앱 사업자 서명"
 }
 ```
 
@@ -172,8 +172,8 @@ def object ServerTokenData: "server token data"
     + walletId             "walletId"  : "wallet id"
     + appId                "caAppId"   : "인가앱 id"
     + utcDatetime          "validUntil": "token 만료 일시"
-    + Provider             "provider"  : "사업자 정보"
+    + Provider             "provider"  : "인가앱 사업자 정보"
     + multibase            "nonce"     : "provider nonce", byte_length(16)
-    + AssertProof          "proof"     : "provider proof - 사업자 서명"
+    + AssertProof          "proof"     : "provider proof - 인가앱 사업자 서명"
 }
 ```


### PR DESCRIPTION

## Description
Fixed an issue where the signing party was incorrectly assigned (mislabeled) during the generation of wallet and server tokens. This PR ensures the correct entity is used for signing the tokens.


## Changes
- Corrected the signing party assignment logic in the wallet token generation process.
- token.md, token_ko.md

